### PR TITLE
fix: dynamic base path

### DIFF
--- a/.github/workflows/publish-pages.yml
+++ b/.github/workflows/publish-pages.yml
@@ -38,7 +38,7 @@ jobs:
         run: yarn --immutable
       - name: Update package.json homepage field
         run: |
-          sed -i 's/"homepage": ".*"/"homepage": "https:\/\/metamask.github.io\/metamask-pay-dapp\/${{ inputs.destination_dir }}"/' package.json
+          sed -i 's/"homepage": ".*"/"homepage": "https:\/\/metamask.github.io\/test-dapp-mm-pay\/${{ inputs.destination_dir }}"/' package.json
       - name: Build DApp
         run: yarn build
       - name: Deploy to `${{ inputs.destination_dir }}` directory of `gh-pages` branch

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/test-dapp-mm-pay",
-  "homepage": "https://metamask.github.io/metamask-pay-dapp",
+  "homepage": "https://metamask.github.io/test-dapp-mm-pay",
   "description": "Test Dapp for benchmarking MetaMask Pay and its competitors",
   "bugs": {
     "url": "https://github.com/MetaMask/test-dapp-mm-pay/issues"

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,10 +3,15 @@ import path from 'path';
 import { defineConfig } from 'vite';
 import { nodePolyfills } from 'vite-plugin-node-polyfills';
 
+import { homepage } from './package.json';
+
+// eslint-disable-next-line require-unicode-regexp
+const basePath = homepage.replace(/^https?:\/\/[^/]+/, '');
+
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [nodePolyfills(), react()],
-  base: process.env.NODE_ENV === 'production' ? '/metamask-pay-dapp/' : '/',
+  base: process.env.ENV === 'production' ? basePath : '/',
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src'),

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,7 +11,7 @@ const basePath = homepage.replace(/^https?:\/\/[^/]+/, '');
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [nodePolyfills(), react()],
-  base: process.env.ENV === 'production' ? basePath : '/',
+  base: process.env.NODE_ENV === 'production' ? basePath : '/',
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src'),


### PR DESCRIPTION
This PR updates  `vite.config` to fetch the base path from `package.json` to support dynamic subpaths (latest and versions) on gh-pages deployments