### PR TITLE
fix: biconomy client transport default rpc

### DIFF
--- a/src/integrations/biconomy/use-biconomy-client.ts
+++ b/src/integrations/biconomy/use-biconomy-client.ts
@@ -8,11 +8,11 @@ import { useQuery } from '@tanstack/react-query';
 import { http, type WalletClient } from 'viem';
 import { useWalletClient } from 'wagmi';
 
-import { CHAIN_CONFIGS } from '@/lib/wagmi';
+import { CHAIN_CONFIGS, INFURA_KEY } from '@/lib/wagmi';
 
 const chainConfigurations = CHAIN_CONFIGS.map(({ chain, rpcUrl }) => ({
   chain,
-  transport: http(rpcUrl),
+  transport: INFURA_KEY ? http(rpcUrl) : http(),
   version: getMEEVersion(MEEVersion.V2_1_0),
 }));
 

--- a/src/lib/wagmi.ts
+++ b/src/lib/wagmi.ts
@@ -2,7 +2,7 @@ import type { Chain, Transport } from 'viem';
 import { createConfig, http } from 'wagmi';
 import { arbitrum, base } from 'wagmi/chains';
 
-const INFURA_KEY: string = import.meta.env.VITE_INFURA_KEY;
+export const INFURA_KEY: string = import.meta.env.VITE_INFURA_KEY;
 
 export const CHAIN_CONFIGS: { chain: Chain; rpcUrl: string }[] = [
   {
@@ -17,9 +17,7 @@ export const CHAIN_CONFIGS: { chain: Chain; rpcUrl: string }[] = [
 
 const transports = CHAIN_CONFIGS.reduce<Record<number, Transport>>(
   (acc, chainConfig) => {
-    acc[chainConfig.chain.id] = INFURA_KEY
-      ? http(chainConfig.rpcUrl)
-      : http(chainConfig.chain.rpcUrls.default.http[0]);
+    acc[chainConfig.chain.id] = INFURA_KEY ? http(chainConfig.rpcUrl) : http();
     return acc;
   },
   {},


### PR DESCRIPTION
## Description

Correctly get the default provider for the biconomy client when there's no Infura API key specified 