### PR TITLE
chore: DevX cleanup after MM Pay integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,8 @@
 # Infura API Key (get from https://infura.io)
+# Used as the default RPC transport for wagmi chains.
 VITE_INFURA_KEY=your_infura_api_key_here
 
-# Dynamic.xyz Environment ID (get from https://app.dynamic.xyz/dashboard/developer/api)
-VITE_DYNAMIC_ENVIRONMENT_ID=dynamic-environment-id
+# WalletConnect Cloud Project ID (get from https://cloud.reown.com)
+# Required for RainbowKit / WalletConnect wallet connections.
+VITE_WALLETCONNECT_PROJECT_ID=your_walletconnect_project_id_here
 
-# Privy App ID  (get from https://dashboard.privy.io)
-VITE_PRIVY_APP_ID=privy-app-id

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- MetaMask Pay integration: `AppMmPay` demo exercising `wallet_sendCalls` / `wallet_getCallsStatus` against Aave on Base, with a two-column user-flow + developer-logs layout ([#27](https://github.com/MetaMask/test-dapp-mm-pay/pull/27))
+- RainbowKit as the default wallet provider ([#19](https://github.com/MetaMask/test-dapp-mm-pay/pull/19))
+
+### Changed
+
+- Theme tokens driven by `[data-mm-pay-demo]` + Tailwind `pay-*` colors; demo uses Motion for transitions and shadcn/Radix primitives
+- `.env.example`: replaced `VITE_DYNAMIC_ENVIRONMENT_ID` / `VITE_PRIVY_APP_ID` with `VITE_WALLETCONNECT_PROJECT_ID`
+
+### Removed
+
+- Dynamic.xyz and Privy wallet providers (superseded by RainbowKit)
+- Relay.link + Biconomy cross-chain routing scaffolding
+
 ## [0.0.6]
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -22,10 +22,10 @@ The default Vite entry (`src/main.tsx`) loads the **MetaMask Pay Demo** (`AppMmP
 
 ### Environment variables
 
-| Variable | Required | Where to get it |
-| --- | --- | --- |
-| `VITE_INFURA_KEY` | Yes | [infura.io](https://infura.io) — used as the default RPC transport for wagmi chains. |
-| `VITE_WALLETCONNECT_PROJECT_ID` | Yes | [cloud.reown.com](https://cloud.reown.com) — required for RainbowKit / WalletConnect wallet connections. Without it, the WalletConnect option silently fails. |
+| Variable                        | Required | Where to get it                                                                                                                                               |
+| ------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `VITE_INFURA_KEY`               | Yes      | [infura.io](https://infura.io) — used as the default RPC transport for wagmi chains.                                                                          |
+| `VITE_WALLETCONNECT_PROJECT_ID` | Yes      | [cloud.reown.com](https://cloud.reown.com) — required for RainbowKit / WalletConnect wallet connections. Without it, the WalletConnect option silently fails. |
 
 ### Testing and Linting
 

--- a/README.md
+++ b/README.md
@@ -4,12 +4,7 @@ Test Dapp for benchmarking Metamask Pay and its competitors.
 
 ## Usage
 
-Currently it allows for supplying USDC to Aave on Base by spending WETH on Arbitrum via Relay.link and Biconomy.
-Route has been hardcoded for simplicity but could easily be adapted to support more tokens.
-
-### MetaMask Pay demo (`AppMmPay`)
-
-The default Vite entry (`src/main.tsx`) loads **MetaMask Pay Demo** — a two-column layout (user flow + developer logs) for exercising `wallet_sendCalls` / `wallet_getCallsStatus` on Aave (Base). Hyperliquid and Polymarket tiles are UI placeholders for now.
+The default Vite entry (`src/main.tsx`) loads the **MetaMask Pay Demo** (`AppMmPay`) — a two-column layout (user flow + developer logs) for exercising `wallet_sendCalls` / `wallet_getCallsStatus` against Aave on Base. Hyperliquid and Polymarket tiles are UI placeholders for now.
 
 - **Theme tokens:** demo chrome uses `[data-mm-pay-demo]` and Tailwind `pay-*` colors (see `src/index.css` and `tailwind.config.ts`). Adjust those variables to re-skin the demo without hunting through components.
 - **Motion:** the demo uses [Motion](https://motion.dev) for light transitions; primitives are shadcn/Radix where it helps accessibility (`Button`, `Input`, `Label`, `Badge`, `ScrollArea`, `Collapsible`, etc.).
@@ -22,12 +17,23 @@ The default Vite entry (`src/main.tsx`) loads **MetaMask Pay Demo** — a two-co
   - If you are using [nvm](https://github.com/creationix/nvm#installation) (recommended) running `nvm install` will install the latest version and running `nvm use` will automatically choose the right node version for you.
 - Install [Yarn](https://yarnpkg.com) v4 via [Corepack](https://github.com/nodejs/corepack?tab=readme-ov-file#how-to-install)
 - Run `yarn install` to install dependencies and run any required post-install scripts
-- Copy `.env.example` to `.env` and setup
+- Copy `.env.example` to `.env` and fill in the required values (see [Environment variables](#environment-variables) below)
 - Run `yarn dev` to spin up the app
+
+### Environment variables
+
+| Variable | Required | Where to get it |
+| --- | --- | --- |
+| `VITE_INFURA_KEY` | Yes | [infura.io](https://infura.io) — used as the default RPC transport for wagmi chains. |
+| `VITE_WALLETCONNECT_PROJECT_ID` | Yes | [cloud.reown.com](https://cloud.reown.com) — required for RainbowKit / WalletConnect wallet connections. Without it, the WalletConnect option silently fails. |
 
 ### Testing and Linting
 
-Run `yarn lint` to run the linter, or run `yarn lint:fix` to run the linter and fix any automatically fixable issues.
+- `yarn test` — run the test suite once (Vitest).
+- `yarn test:watch` — re-run tests on change.
+- `yarn test:ui` — Vitest UI.
+- `yarn lint` — run ESLint + Prettier checks.
+- `yarn lint:fix` — auto-fix lint/format issues.
 
 ### Release & Publishing
 

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -5,7 +5,7 @@
 declare global {
   interface ImportMetaEnv {
     readonly VITE_INFURA_KEY: string;
-    readonly VITE_BICONOMY_API_KEY: string;
+    readonly VITE_WALLETCONNECT_PROJECT_ID: string;
   }
 
   interface ImportMeta {


### PR DESCRIPTION
## Summary

Post-merge cleanup to address stale DevX left behind by the MM Pay integration PR (#27).

- **README**: rewrote the outdated "USDC via Relay.link + Biconomy" intro; added an **Environment variables** table (required vars + where to get them); expanded Testing/Linting section to cover Vitest scripts.
- **`.env.example`**: removed stale `VITE_DYNAMIC_ENVIRONMENT_ID` / `VITE_PRIVY_APP_ID` (providers were removed); added `VITE_WALLETCONNECT_PROJECT_ID`, which RainbowKit reads but was silently defaulting to `""` for fresh clones.
- **`src/vite-env.d.ts`**: dropped dead `VITE_BICONOMY_API_KEY` (declared but no longer read anywhere); added `VITE_WALLETCONNECT_PROJECT_ID`.
- **CHANGELOG**: populated `[Unreleased]` with Added / Changed / Removed entries for the MM Pay integration, RainbowKit default, and the Dynamic/Privy/Biconomy/Relay removals. Version bump left to the MetaMask release-PR action.

## Why

A fresh clone after #27 hit two silent failures:
1. WalletConnect connections failed because the env var wasn't in `.env.example`.
2. The README still described the pre-refactor Aave-via-Relay flow.

## Test plan

- [ ] \`yarn install && yarn dev\` starts cleanly with a filled-in \`.env\` from the updated \`.env.example\`
- [ ] WalletConnect option in RainbowKit works when \`VITE_WALLETCONNECT_PROJECT_ID\` is set
- [ ] \`yarn lint\` passes
- [ ] \`yarn lint:changelog\` passes
- [ ] \`npx tsc --noEmit\` passes